### PR TITLE
fix: userInput is not deleted on bot message

### DIFF
--- a/src/components/Widget/components/Conversation/components/Sender/index.js
+++ b/src/components/Widget/components/Conversation/components/Sender/index.js
@@ -30,7 +30,6 @@ const Sender = ({ sendMessage, inputTextFieldHint, disabledInput, userInput, set
 ))};
 const mapStateToProps = state => ({
   inputTextFieldHint: state.behavior.get('inputTextFieldHint'),
-  // userInput: state.metadata.get('userInput'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Widget/components/Conversation/components/Sender/index.js
+++ b/src/components/Widget/components/Conversation/components/Sender/index.js
@@ -30,7 +30,7 @@ const Sender = ({ sendMessage, inputTextFieldHint, disabledInput, userInput, set
 ))};
 const mapStateToProps = state => ({
   inputTextFieldHint: state.behavior.get('inputTextFieldHint'),
-  userInput: state.metadata.get('userInput'),
+  // userInput: state.metadata.get('userInput'),
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
**Proposed changes**:
- State of userInput is not changed when the bot sends a message.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
