### PR TITLE
fix: text overflow

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
@@ -22,7 +22,7 @@
     @include message-bubble($blue-1, #fff);
     margin-left: auto;
     overflow-wrap: break-word;
-
+    overflow: auto;
     a {
       color: $turqois-1;
     }

--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
@@ -31,6 +31,7 @@
   .response {
     @include message-bubble(#000, #292929, 0 15px 15px 15px);
     overflow-wrap: break-word;
+    overflow: auto;
   }
 
   /* For markdown elements created with default styles */

--- a/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/styles.scss
@@ -3,6 +3,10 @@
 
 .conversation-container {
 
+  .quickReplies-container {
+    overflow: auto;
+  }
+
   .replies {
     @include replies;
   }


### PR DESCRIPTION
**Proposed changes**:
- Added css property to handle overflow in text responses.

**Issue**: 
![Clipboard - 25 de Junho de 2020 às 14_47](https://user-images.githubusercontent.com/30026625/85775261-0167a080-b6f6-11ea-92a6-459b97a5fc8e.png)


**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
