### PR TITLE
feat: new attributes showHeaderAvatar and fullScreenBotMessageBubbleColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ params={{
 | `quickRepliesBackgroundColor` | `none`         | `color`     | Set the Quick-Replies background-color |
 | `quickRepliesBorderColor`     | `#0084ff`      | `color`     | Set the Quick-Replies border color     |
 | `quickRepliesBorderWidth`     | `1px`          | `dimension` | Set the Quick-Replies border width     |
-| `fullScreenMessageBubbleColor` | `rgba(0,0,0,0)` | `color` | Set the bot message bubble color on fullscreen mode | 
+| `fullScreenBotMessageBubbleColor` | `rgba(0,0,0,0)` | `color` | Set the bot message bubble color on fullscreen mode | 
 
 ### Other features
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ set to `true` if you don't want to see the launcher.
 | `tooltipMessage` | `null` | Message that will be displayed as tooltip |
 | `tooltipDelay` | `500` | Delay for the `tooltipMessage` |
 | `disableTooltips` | `false` | Boolean to define if tooltips should be displayed |
+| `showHeaderAvatar` | `true` | Boolean to define if the image provided in `profileAvatar` attribute must be displayed in Header |
 
 
 
@@ -165,6 +166,7 @@ params={{
 | `quickRepliesBackgroundColor` | `none`         | `color`     | Set the Quick-Replies background-color |
 | `quickRepliesBorderColor`     | `#0084ff`      | `color`     | Set the Quick-Replies border color     |
 | `quickRepliesBorderWidth`     | `1px`          | `dimension` | Set the Quick-Replies border width     |
+| `fullScreenMessageBubbleColor` | `rgba(0,0,0,0)` | `color` | Set the bot message bubble color on fullscreen mode | 
 
 ### Other features
 

--- a/dev/src/index.html
+++ b/dev/src/index.html
@@ -70,7 +70,8 @@
       quickRepliesFontColor: "#0084ff",
       quickRepliesBackgroundColor: "none",
       quickRepliesBorderColor: "#0084ff",
-      quickRepliesBorderWidth: "1px"
+      quickRepliesBorderWidth: "1px",
+      fullScreenMessageBubbleColor: "rgba(0, 0, 0, 0)"
     }
   })
   WebChat.open();

--- a/dev/src/index.html
+++ b/dev/src/index.html
@@ -71,7 +71,7 @@
       quickRepliesBackgroundColor: "none",
       quickRepliesBorderColor: "#0084ff",
       quickRepliesBorderWidth: "1px",
-      fullScreenMessageBubbleColor: "rgba(0, 0, 0, 0)"
+      fullScreenBotMessageBubbleColor: "rgba(0, 0, 0, 0)"
     }
   })
   WebChat.open();

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const plugin = {
         defaultHighlightAnimation={args.defaultHighlightAnimation}
         defaultHighlightClassname={args.defaultHighlightClassname}
         customizeWidget={args.customizeWidget}
+        showHeaderAvatar={args.showHeaderAvatar}
       />, document.querySelector(args.selector)
     );
   }

--- a/src/components/Widget/components/Conversation/components/Header/index.js
+++ b/src/components/Widget/components/Conversation/components/Header/index.js
@@ -18,14 +18,15 @@ const Header = ({
   connected,
   connectingText,
   closeImage,
-  profileAvatar
+  profileAvatar,
+  showHeaderAvatar
 }) => {
     
     return(
       <div className="push-header-and-loading">
-        <div className={`push-header ${subtitle ? 'push-with-subtitle' : ''}`}>
+        <div className={`push-header ${subtitle ? 'push-with-subtitle' : ''} ${(showHeaderAvatar && profileAvatar) ? '' : 'push-without-header-avatar'}`}>
           {
-            profileAvatar && (
+            showHeaderAvatar && profileAvatar && (
               <img src={profileAvatar} className="push-avatar" alt="chat avatar" />
             )
           }
@@ -51,8 +52,10 @@ const Header = ({
               </button>
             }
           </div>
-          <h4 className={`push-title ${profileAvatar && 'push-with-avatar'}`}>{title}</h4>
-          {subtitle && <span className={`push-subtitle ${profileAvatar && 'push-with-avatar'}`}>{subtitle}</span>}
+          <div className={'push-title-and-subtitle'}>
+            <h4 className={`push-title ${profileAvatar && 'push-with-avatar'}`}>{title}</h4>
+            {subtitle && <span className={`push-subtitle ${profileAvatar && 'push-with-avatar'}`}>{subtitle}</span>}
+          </div>
         </div>
         {
           !connected &&
@@ -75,7 +78,8 @@ Header.propTypes = {
   connected: PropTypes.bool,
   connectingText: PropTypes.string,
   closeImage: PropTypes.string,
-  profileAvatar: PropTypes.string
+  profileAvatar: PropTypes.string,
+  showHeaderAvatar: PropTypes.bool
 };
 
 export default Header;

--- a/src/components/Widget/components/Conversation/components/Header/style.scss
+++ b/src/components/Widget/components/Conversation/components/Header/style.scss
@@ -22,6 +22,12 @@
     }
   }
 
+  .push-header.push-without-header-avatar {
+    .push-title-and-subtitle {
+      margin-left: -4vh;
+    }
+  }
+
   .push-header.push-with-subtitle {
     height: 70px;
     .push-avatar {
@@ -104,6 +110,12 @@
     }
   }
 
+  .push-header.push-without-header-avatar {
+    .push-title-and-subtitle {
+      margin-left: 4vh;
+    }
+  }
+
   .push-title {
     @include push-title-fs;
   }
@@ -134,6 +146,7 @@
       @include push-header-fs;
       min-height: 5vh!important;
       padding-left: 0vh!important;
+      text-align: center !important;
       .push-avatar {
         display: none;
       }
@@ -146,6 +159,12 @@
         margin: 0;
       }
     }
+
+    .push-header.push-without-header-avatar {
+      .push-title-and-subtitle {
+        margin-left: 0vh;
+      }
+    } 
 
     .push-title {
       @include push-title-fs;

--- a/src/components/Widget/components/Conversation/index.js
+++ b/src/components/Widget/components/Conversation/index.js
@@ -20,6 +20,7 @@ const Conversation = props =>
       connectingText={props.connectingText}
       closeImage={props.closeImage}
       profileAvatar={props.profileAvatar}
+      showHeaderAvatar={props.showHeaderAvatar}
     />
     <Messages
       profileAvatar={props.profileAvatar}
@@ -52,7 +53,8 @@ Conversation.propTypes = {
   closeImage: PropTypes.string,
   customComponent: PropTypes.func,
   showMessageDate: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
-  inputTextFieldHint: PropTypes.string
+  inputTextFieldHint: PropTypes.string,
+  showHeaderAvatar: PropTypes.bool
 };
 
 export default Conversation;

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -567,6 +567,7 @@ class Widget extends Component {
         tooltipMessage={this.props.tooltipMessage}
         customizeWidget={this.props.customizeWidget}
         inputTextFieldHint={this.props.inputTextFieldHint}
+        showHeaderAvatar={this.props.showHeaderAvatar}
       />
     );
   }
@@ -619,7 +620,8 @@ Widget.propTypes = {
   defaultHighlightAnimation: PropTypes.string,
   defaultHighlightCss: PropTypes.string,
   defaultHighlightClassname: PropTypes.string,
-  inputTextFieldHint: PropTypes.string
+  inputTextFieldHint: PropTypes.string,
+  showHeaderAvatar: PropTypes.bool,
 };
 
 Widget.defaultProps = {
@@ -644,7 +646,8 @@ Widget.defaultProps = {
       outline-color: green;
     }
   }`,
-  customizeWidget: {}
+  customizeWidget: {},
+  showHeaderAvatar: true
 };
 
 export default connect(mapStateToProps, null, null, { forwardRef: true })(Widget);

--- a/src/components/Widget/layout.js
+++ b/src/components/Widget/layout.js
@@ -49,6 +49,7 @@ const WidgetLayout = (props) => {
           closeImage={props.closeImage}
           customComponent={props.customComponent}
           showMessageDate={props.showMessageDate}
+          showHeaderAvatar={props.showHeaderAvatar}
         />
       )}
       {!props.embedded && (
@@ -100,7 +101,8 @@ WidgetLayout.propTypes = {
   displayUnreadCount: PropTypes.bool,
   showMessageDate: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   tooltipMessage: PropTypes.string,
-  inputTextFieldHint: PropTypes.string
+  inputTextFieldHint: PropTypes.string,
+  showHeaderAvatar: PropTypes.bool
 };
 
 export default connect(mapStateToProps)(WidgetLayout);

--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,7 @@ const ConnectedWidget = forwardRef((props, ref) => {
         defaultHighlightClassname={props.defaultHighlightClassname}
         customizeWidget={props.customizeWidget}
         inputTextFieldHint={props.inputTextFieldHint}
+        showHeaderAvatar={props.showHeaderAvatar}
       />
     </Provider>
   );
@@ -187,7 +188,8 @@ ConnectedWidget.propTypes = {
   }),
   disableTooltips: PropTypes.bool,
   defaultHighlightCss: PropTypes.string,
-  defaultHighlightAnimation: PropTypes.string
+  defaultHighlightAnimation: PropTypes.string,
+  showHeaderAvatar: PropTypes.bool,
 };
 
 ConnectedWidget.defaultProps = {
@@ -228,7 +230,8 @@ ConnectedWidget.defaultProps = {
     onChatVisible: () => {},
     onChatHidden: () => {}
   },
-  disableTooltips: false
+  disableTooltips: false,
+  showHeaderAvatar: true,
 };
 
 export default ConnectedWidget;

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -35,7 +35,7 @@ $roboto: 'Roboto', serif;
   border-radius: 0;
   flex-shrink: 0;
   position: relative;
-  text-align: center;
+  text-align: left;
 }
 
 @mixin push-title-fs {
@@ -121,7 +121,7 @@ $roboto: 'Roboto', serif;
     }
 
     .push-response {
-      background-color: rgba(0,0,0,0)
+      background-color: var(--fullScreenMessageBubbleColor)
     }
   }
 }

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -121,7 +121,7 @@ $roboto: 'Roboto', serif;
     }
 
     .push-response {
-      background-color: var(--fullScreenMessageBubbleColor)
+      background-color: var(--fullScreenBotMessageBubbleColor)
     }
   }
 }

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -19,7 +19,7 @@
     --quickRepliesBackgroundColor: none;
     --quickRepliesBorderColor: #0084ff;
     --quickRepliesBorderWidth: 1px;
-    --fullScreenMessageBubbleColor: rgba(0, 0, 0 ,0)
+    --fullScreenBotMessageBubbleColor: rgba(0, 0, 0 ,0)
 }
 
 

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -19,6 +19,7 @@
     --quickRepliesBackgroundColor: none;
     --quickRepliesBorderColor: #0084ff;
     --quickRepliesBorderWidth: 1px;
+    --fullScreenMessageBubbleColor: rgba(0, 0, 0 ,0)
 }
 
 


### PR DESCRIPTION
**Proposed changes**:
- New param for the widget that enables or disables the avatar on header: `showHeaderAvatar`
- New attribute for the `customizeWidget` param to change the bot message bubble color when on fullscreen mode: `fullScreenBotMessageBubbleColor`



**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [X] updated the documentation
- [ ] updated the changelog
