### PR TITLE
fix: messages alignment

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/styles.scss
@@ -43,7 +43,7 @@
       display: none;
     }
     &.push-with-avatar {
-      margin-left: 33px;
+      margin-left: 49px;
     }
   }
   // When we have several messages, the last one of the group
@@ -92,6 +92,14 @@
       padding: 0;
     }
   }
+
+  .push-group-message.push-from-response {
+    .push-message:not(:first-child):not(:only-child) {
+      &.push-with-avatar {
+        margin-left: 43px;
+      }
+    }
+  }
 }
 
 @media screen and (max-width: 800px)  {
@@ -109,6 +117,15 @@
       margin: 0.5em 0 0 -1.5em;
     }
   }
+
+  .push-group-message.push-from-response {
+    .push-message:not(:first-child):not(:only-child) {
+      &.push-with-avatar {
+        margin-left: 40px;
+      }
+    }
+  }
+
 }
 
 div#push-wave {


### PR DESCRIPTION
**Proposed changes**:
- Messages in a row are now properly aligned
- Before:
![image](https://user-images.githubusercontent.com/30026625/87787752-86843800-c812-11ea-8c3a-331db954329c.png)
- After:
![image](https://user-images.githubusercontent.com/30026625/87787834-aca9d800-c812-11ea-824b-ae42e81063a2.png)



**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
