### PR TITLE
fix: div blocking page interaction

### DIFF
--- a/src/components/Widget/style.scss
+++ b/src/components/Widget/style.scss
@@ -8,12 +8,14 @@
   padding: 0 1vh 1vh 0;
   position: fixed;
   right: 0;
-  width: var(--widgetWidth);
-  height: var(--widgetHeight);
   z-index: 9999;
   align-items: flex-end;
-  justify-content: flex-end;
-  
+  justify-content: flex-end;  
+
+  &.push-chat-open {
+    width: var(--widgetWidth);
+    height: var(--widgetHeight);
+  }
 
   &.push-full-screen.push-chat-open {
     @include push-widget-container-fs;


### PR DESCRIPTION
**Proposed changes**:
- Fixed a bug that a div width/height was set even when the chat was closed, making that div on top of the page and that space not accepting user input.
- Now that div width/height is rendered only when the chat is open.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
