### PR TITLE
Feat/header image

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ set to `true` if you don't want to see the launcher.
 | `tooltipDelay` | `500` | Delay for the `tooltipMessage` |
 | `disableTooltips` | `false` | Boolean to define if tooltips should be displayed |
 | `showHeaderAvatar` | `true` | Boolean to define if the image provided in `profileAvatar` attribute must be displayed in Header |
+| `headerImage` | `null` | If provided, the image will be displayed in place of `profileImage`, `title` and `subtitle` |
 
 
 

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ const plugin = {
         customizeWidget={args.customizeWidget}
         showHeaderAvatar={args.showHeaderAvatar}
         sessionId={args.sessionId}
+        headerImage={args.headerImage}
       />, document.querySelector(args.selector)
     );
   }

--- a/src/components/Widget/components/Conversation/components/Header/index.js
+++ b/src/components/Widget/components/Conversation/components/Header/index.js
@@ -19,16 +19,19 @@ const Header = ({
   connectingText,
   closeImage,
   profileAvatar,
-  showHeaderAvatar
+  showHeaderAvatar,
+  headerImage
 }) => {
-    
     return(
       <div className="push-header-and-loading">
         <div className={`push-header ${subtitle ? 'push-with-subtitle' : ''} ${(showHeaderAvatar && profileAvatar) ? '' : 'push-without-header-avatar'}`}>
           {
-            showHeaderAvatar && profileAvatar && (
-              <img src={profileAvatar} className="push-avatar" alt="chat avatar" />
-            )
+            headerImage ?
+              <img src={headerImage} className="push-header-image" alt="chat header image" />
+              :
+              showHeaderAvatar && profileAvatar && (
+                <img src={profileAvatar} className="push-avatar" alt="chat avatar" />
+              )
           }
           <div className="push-header-buttons">
             {
@@ -52,10 +55,13 @@ const Header = ({
               </button>
             }
           </div>
-          <div className={'push-title-and-subtitle'}>
-            <h4 className={`push-title ${profileAvatar && 'push-with-avatar'}`}>{title}</h4>
-            {subtitle && <span className={`push-subtitle ${profileAvatar && 'push-with-avatar'}`}>{subtitle}</span>}
-          </div>
+          {
+            !headerImage &&
+              <div className={'push-title-and-subtitle'}>
+                <h4 className={`push-title ${profileAvatar && 'push-with-avatar'}`}>{title}</h4>
+                {subtitle && <span className={`push-subtitle ${profileAvatar && 'push-with-avatar'}`}>{subtitle}</span>}
+              </div>
+          }
         </div>
         {
           !connected &&
@@ -79,7 +85,8 @@ Header.propTypes = {
   connectingText: PropTypes.string,
   closeImage: PropTypes.string,
   profileAvatar: PropTypes.string,
-  showHeaderAvatar: PropTypes.bool
+  showHeaderAvatar: PropTypes.bool,
+  headerImage: PropTypes.string
 };
 
 export default Header;

--- a/src/components/Widget/components/Conversation/components/Header/style.scss
+++ b/src/components/Widget/components/Conversation/components/Header/style.scss
@@ -20,6 +20,12 @@
       top: 12px;
       left: 14px;
     }
+    .push-header-image {
+      height: 70%;
+      width: 50%;
+      position: absolute;
+      left: 2px;
+    }
   }
 
   .push-header.push-without-header-avatar {
@@ -108,6 +114,12 @@
       top: 2.5vh;
       left: 3vh;
     }
+    .push-header-image {
+      width: 30vh;
+      height: 8vh;
+      position: absolute;
+      left: 3vh;
+    }
   }
 
   .push-header.push-without-header-avatar {
@@ -149,6 +161,11 @@
       text-align: center !important;
       .push-avatar {
         display: none;
+      }
+      .push-header-image {
+        height: 7vh;
+        width: 24vh;
+        left: 2vh;
       }
 
       span.push-with-avatar, span.push-subtitle {

--- a/src/components/Widget/components/Conversation/index.js
+++ b/src/components/Widget/components/Conversation/index.js
@@ -21,6 +21,7 @@ const Conversation = props =>
       closeImage={props.closeImage}
       profileAvatar={props.profileAvatar}
       showHeaderAvatar={props.showHeaderAvatar}
+      headerImage={props.headerImage}
     />
     <Messages
       profileAvatar={props.profileAvatar}
@@ -54,7 +55,8 @@ Conversation.propTypes = {
   customComponent: PropTypes.func,
   showMessageDate: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   inputTextFieldHint: PropTypes.string,
-  showHeaderAvatar: PropTypes.bool
+  showHeaderAvatar: PropTypes.bool,
+  headerImage: PropTypes.string
 };
 
 export default Conversation;

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -571,6 +571,7 @@ class Widget extends Component {
         customizeWidget={this.props.customizeWidget}
         inputTextFieldHint={this.props.inputTextFieldHint}
         showHeaderAvatar={this.props.showHeaderAvatar}
+        headerImage={this.props.headerImage}
       />
     );
   }
@@ -625,7 +626,8 @@ Widget.propTypes = {
   defaultHighlightClassname: PropTypes.string,
   inputTextFieldHint: PropTypes.string,
   showHeaderAvatar: PropTypes.bool,
-  sessionId: PropTypes.string
+  sessionId: PropTypes.string,
+  headerImage: PropTypes.string,
 };
 
 Widget.defaultProps = {

--- a/src/components/Widget/layout.js
+++ b/src/components/Widget/layout.js
@@ -50,6 +50,7 @@ const WidgetLayout = (props) => {
           customComponent={props.customComponent}
           showMessageDate={props.showMessageDate}
           showHeaderAvatar={props.showHeaderAvatar}
+          headerImage={props.headerImage}
         />
       )}
       {!props.embedded && (
@@ -102,7 +103,8 @@ WidgetLayout.propTypes = {
   showMessageDate: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   tooltipMessage: PropTypes.string,
   inputTextFieldHint: PropTypes.string,
-  showHeaderAvatar: PropTypes.bool
+  showHeaderAvatar: PropTypes.bool,
+  headerImage: PropTypes.string,
 };
 
 export default connect(mapStateToProps)(WidgetLayout);

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,7 @@ const ConnectedWidget = forwardRef((props, ref) => {
         inputTextFieldHint={props.inputTextFieldHint}
         showHeaderAvatar={props.showHeaderAvatar}
         sessionId={props.sessionId}
+        headerImage={props.headerImage}
       />
     </Provider>
   );
@@ -192,6 +193,7 @@ ConnectedWidget.propTypes = {
   defaultHighlightAnimation: PropTypes.string,
   showHeaderAvatar: PropTypes.bool,
   sessionId: PropTypes.string,
+  headerImage: PropTypes.string,
 };
 
 ConnectedWidget.defaultProps = {


### PR DESCRIPTION
**Proposed changes**:
- New attribute `headerImage`, to insert an image in place of `profileAvatar`, `title`, and `subtitle` on the header.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [X] updated the documentation
- [ ] updated the changelog
