### PR TITLE
Feat/start in fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ set to `true` if you don't want to see the launcher.
 | `closeImage` | `null` | Image to be displayed on the Launcher while the chat is open |
 | `connectingText` | `'Waiting for server...'` | Message displayed while the connection between the widget and socket server is established |
 | `showCloseButton` | `true` | Boolean to define if the close button will be shown |
-| `fullScreenMode` | `false` | Boolean to define if the widget is started on fullscreen mode |
+| `startFullScreen` | `false` | Boolean to define if the widget is started on fullscreen mode |
 | `tooltipMessage` | `null` | Message that will be displayed as tooltip |
 | `tooltipDelay` | `500` | Delay for the `tooltipMessage` |
 | `disableTooltips` | `false` | Boolean to define if tooltips should be displayed |

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ const plugin = {
         showHeaderAvatar={args.showHeaderAvatar}
         sessionId={args.sessionId}
         headerImage={args.headerImage}
+        startFullScreen={args.startFullScreen}
       />, document.querySelector(args.selector)
     );
   }

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -52,18 +52,21 @@ class Widget extends Component {
 
 
   componentDidMount() {
-    const { connectOn, autoClearCache, storage, dispatch, defaultHighlightAnimation } = this.props;
+    const { connectOn, autoClearCache, storage, dispatch, defaultHighlightAnimation, startFullScreen } = this.props;
 
     const styleNode = document.createElement('style');
     styleNode.innerHTML = defaultHighlightAnimation;
     document.body.appendChild(styleNode);
+
+    if (startFullScreen) {
+      this.toggleFullScreen();
+    }
 
     this.intervalId = setInterval(() => dispatch(evalUrl(window.location.href)), 500);
     if (connectOn === 'mount') {
       this.initializeWidget();
       return;
     }
-
 
     const localSession = getLocalSession(storage, SESSION_NAME);
     const lastUpdate = localSession ? localSession.lastUpdate : 0;
@@ -628,6 +631,7 @@ Widget.propTypes = {
   showHeaderAvatar: PropTypes.bool,
   sessionId: PropTypes.string,
   headerImage: PropTypes.string,
+  startFullScreen: PropTypes.bool
 };
 
 Widget.defaultProps = {
@@ -655,6 +659,7 @@ Widget.defaultProps = {
   customizeWidget: {},
   showHeaderAvatar: true,
   sessionId: null,
+  startFullScreen: false
 };
 
 export default connect(mapStateToProps, null, null, { forwardRef: true })(Widget);

--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,7 @@ const ConnectedWidget = forwardRef((props, ref) => {
         showHeaderAvatar={props.showHeaderAvatar}
         sessionId={props.sessionId}
         headerImage={props.headerImage}
+        startFullScreen={props.startFullScreen}
       />
     </Provider>
   );
@@ -194,6 +195,7 @@ ConnectedWidget.propTypes = {
   showHeaderAvatar: PropTypes.bool,
   sessionId: PropTypes.string,
   headerImage: PropTypes.string,
+  startFullScreen: PropTypes.bool,
 };
 
 ConnectedWidget.defaultProps = {
@@ -237,6 +239,7 @@ ConnectedWidget.defaultProps = {
   disableTooltips: false,
   showHeaderAvatar: true,
   sessionId: null,
+  startFullScreen: false,
 };
 
 export default ConnectedWidget;


### PR DESCRIPTION
**Proposed changes**:
- The `fullScreenMode` attribute could not be used to initialize the widget in full screen because it is used as a state behavior attribute, with that in mind, a new attribute `startFullScreen` has been added, that when the component is being mounted, if this attribute is true, the behavior to change the `fullScreenMode` will be triggered.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [X] updated the documentation
- [ ] updated the changelog
