### PR TITLE
fix: removed initPayload being called on component updates

### DIFF
--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -87,7 +87,6 @@ class Widget extends Component {
       if (!initialized) {
         this.initializeWidget();
       }
-      this.trySendInitPayload();
     }
 
     if (embedded && initialized) {


### PR DESCRIPTION
**Proposed changes**:
- The initPayload was being sent on every page reload, causing the push flow to be started again.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
