### PR TITLE
[FIX] Socket: prevent infinite reconnect loop on register errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.27.2] (2026-04-24)
+
+### Bug Fixes
+
+* fix(socket): prevent infinite reconnect loop on register errors
+
 ## [2.27.1] (2025-12-16)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "push-webchat",
-  "version": "2.26.0",
+  "version": "2.27.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "push-webchat",
-      "version": "2.26.0",
+      "version": "2.27.2",
       "license": "MIT",
       "dependencies": {
         "@material-ui/core": "^4.11.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "push-webchat",
-  "version": "2.27.1",
+  "version": "2.27.2",
   "description": "Chat web widget for React apps and Push chatbots",
   "module": "module/index.js",
   "main": "lib/index.js",

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -103,6 +103,10 @@ class Widget extends Component {
     this.typingTimeoutId = null;
     this.hasUserOpenedChat = false;
     this.reconnectImmediate = false;
+    this.reconnectAttempts = 0;
+    this.recoveryInProgress = false;
+    this.skipRegisterOnNextOpen = false;
+    this.recoveryFallbackTimeout = null;
     this.clientMessageMap = {
       text: insertUserMessage,
       image: insertUserImage,
@@ -214,6 +218,11 @@ class Widget extends Component {
     if (this.reconnectionTimeout) {
       clearTimeout(this.reconnectionTimeout);
       this.reconnectionTimeout = null;
+    }
+
+    if (this.recoveryFallbackTimeout) {
+      clearTimeout(this.recoveryFallbackTimeout);
+      this.recoveryFallbackTimeout = null;
     }
 
     if (socket) {
@@ -414,6 +423,12 @@ class Widget extends Component {
 
     if (receivedMessage.type === 'ready_for_message') {
       this.isReadyToSendMessage = true;
+      this.reconnectAttempts = 0;
+      this.recoveryInProgress = false;
+      if (this.recoveryFallbackTimeout) {
+        clearTimeout(this.recoveryFallbackTimeout);
+        this.recoveryFallbackTimeout = null;
+      }
 
       const historyFromReady = Array.isArray(receivedMessage.data.history) ? receivedMessage.data.history : [];
       this.hasPreviousMessages = historyFromReady.length > 0;
@@ -498,11 +513,19 @@ class Widget extends Component {
       dispatch(setMessagesScroll(true));
       this.dispatchAckAttachment(receivedMessage.message);
     } else if (receivedMessage.type === 'error') {
-      if (receivedMessage.error === 'unable to register: client from already exists') {
+      const errMsg = receivedMessage.error || '';
+      if (errMsg === 'unable to register: client from already exists') {
         console.log('%cSOCKET RECEIVED ERROR - already exists', 'color: #F71963; font-weight: bold;', new Date());
 
         this.props.socket.socket.removeEventListener('close', socketOnCloseListener);
         this.forceChatConnection();
+      } else if (errMsg.startsWith('unable to register:')) {
+        console.log('%cSOCKET RECEIVED ERROR - register failed', 'color: #F71963; font-weight: bold;', new Date());
+        console.log(errMsg);
+
+        this.forceNewSession = true;
+        this.reconnectImmediate = true;
+        this.props.socket.socket.close();
       }
     } else if (receivedMessage.type === 'warning') {
       if (receivedMessage.warning === 'Connection closed by request') {
@@ -510,9 +533,19 @@ class Widget extends Component {
 
         console.log('%cSOCKET RECEIVED WARNING - closed by request', 'color: #F71963; font-weight: bold;', new Date());
 
-        this.props.dispatch(openSessionMessage());
-        this.props.socket.socket.removeEventListener('close', socketOnCloseListener);
-        this.props.socket.socket.close();
+        if (this.recoveryFallbackTimeout) {
+          clearTimeout(this.recoveryFallbackTimeout);
+          this.recoveryFallbackTimeout = null;
+        }
+
+        if (this.recoveryInProgress) {
+          this.reconnectImmediate = true;
+          this.props.socket.socket.close();
+        } else {
+          this.props.dispatch(openSessionMessage());
+          this.props.socket.socket.removeEventListener('close', socketOnCloseListener);
+          this.props.socket.socket.close();
+        }
       }
     } else if (receivedMessage.type === 'forbidden') {
       this.canReconnect = false;
@@ -797,13 +830,17 @@ class Widget extends Component {
         console.log('%cSOCKET ONOPEN', 'color: #F71963; font-weight: bold;', new Date());
 
         if (!that.connected || that.attemptingReconnection) {
-          that.startConnection(
-            this,
-            that.forceNewSession || (!that.attemptingReconnection && sendInitPayload),
-            options,
-            localId,
-            uniqueFrom
-          );
+          if (that.skipRegisterOnNextOpen) {
+            that.skipRegisterOnNextOpen = false;
+          } else {
+            that.startConnection(
+              this,
+              that.forceNewSession || (!that.attemptingReconnection && sendInitPayload),
+              options,
+              localId,
+              uniqueFrom
+            );
+          }
           that.pingIntervalId = setInterval(() => {
             that.pingSocket();
           }, 50000);
@@ -1154,6 +1191,9 @@ class Widget extends Component {
   }
 
   forceChatConnection() {
+    this.recoveryInProgress = true;
+    this.skipRegisterOnNextOpen = true;
+
     afterOnOpen = () => {
       const { sessionToken, socket } = this.props;
 
@@ -1167,8 +1207,18 @@ class Widget extends Component {
       }
 
       socket.socket.send(JSON.stringify(options));
-      this.reconnectImmediate = true;
-      socket.socket.close();
+
+      if (this.recoveryFallbackTimeout) {
+        clearTimeout(this.recoveryFallbackTimeout);
+      }
+      this.recoveryFallbackTimeout = setTimeout(() => {
+        this.recoveryFallbackTimeout = null;
+        if (this.recoveryInProgress && socket.socket && socket.socket.readyState !== 3) {
+          console.log('%cSOCKET RECOVERY FALLBACK', 'color: #F71963; font-weight: bold;', new Date());
+          this.reconnectImmediate = true;
+          socket.socket.close();
+        }
+      }, 3000);
     };
 
     this.attemptingReconnection = true;

--- a/src/components/Widget/socketEvents.js
+++ b/src/components/Widget/socketEvents.js
@@ -1,4 +1,8 @@
-import { closeSessionMessage } from 'actions';
+import { closeSessionMessage, disconnectServer, openSessionMessage } from 'actions';
+
+const MAX_RECONNECT_ATTEMPTS = 10;
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30000;
 
 export function socketOnClose() {
   console.log('%cSOCKET ONCLOSE', 'color: #F71963; font-weight: bold;', new Date());
@@ -9,16 +13,29 @@ export function socketOnClose() {
     return;
   }
 
+  if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+    console.log('%cSOCKET RECONNECT CAP REACHED', 'color: #F71963; font-weight: bold;', new Date());
+    this.canReconnect = false;
+    this.props.dispatch(disconnectServer());
+    this.props.dispatch(openSessionMessage());
+    return;
+  }
+
+  const delay = this.reconnectImmediate
+    ? BASE_DELAY_MS
+    : Math.min(BASE_DELAY_MS * (2 ** this.reconnectAttempts), MAX_DELAY_MS);
+
   if (this.reconnectionTimeout) {
     clearTimeout(this.reconnectionTimeout);
   }
 
   this.reconnectionTimeout = setTimeout(() => {
+    this.reconnectAttempts += 1;
     this.attemptingReconnection = true;
     clearInterval(this.pingIntervalId);
     this.props.dispatch(closeSessionMessage());
     this.initializeWidget(true, true);
-  }, this.reconnectImmediate ? 1000 : 5000);
+  }, delay);
 
   this.reconnectImmediate = false;
 }


### PR DESCRIPTION
## Description

### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Summary of Changes

Fixes an infinite reconnect loop reported by a customer: when the backend returns an `unable to register` error, the widget kept reconnecting every 5s forever.

#### Root causes
* The frontend only handled the exact string `unable to register: client from already exists`. The sibling backend error `unable to register: original handler is dead, wait for unregister to register again` (emitted when the previous owning pod is gone) was silently ignored, leaving the socket in a zombie state that kept triggering unbounded reconnects.
* `socketOnClose` had no max retry cap and no backoff, so any persistent registration failure produced a 5s reconnect loop.
* `forceChatConnection` (the recovery path for `client from already exists`) opened a new socket and sent `register` **before** `close_session`, so the server saw the stale-but-alive registration first and replied with the same error, feeding the loop.

#### Fix
* **Broadened `type: 'error'` handler** (`src/components/Widget/index.js`): any `unable to register:` prefix now recovers by setting `forceNewSession = true` + `reconnectImmediate = true` and closing the socket for a fresh register on the next cycle.
* **Capped reconnect attempts** (`src/components/Widget/socketEvents.js`): `MAX_RECONNECT_ATTEMPTS = 10` with exponential backoff (1s → 2s → 4s → 8s → 16s → 30s, clamped at 30s). On cap, `canReconnect` is set to `false` and both `disconnectServer()` + `openSessionMessage()` are dispatched, showing the same "session closed" UI already used for `Connection closed by request`.
* **Reset counter only on confirmed registration**: `reconnectAttempts` is cleared in the `ready_for_message` handler, not on socket `open`, so partial connects don't falsely reset progress.
* **Fixed the `forceChatConnection` race**: the recovery socket now skips `register` (via a one-shot `skipRegisterOnNextOpen` flag), sends `close_session` only, and waits for the `warning: 'Connection closed by request'` acknowledgment before closing. A 3s fallback timer closes the socket if the warning never arrives. `socketOnClose` then drives the fresh register via the next scheduled cycle with `reconnectImmediate = true`.
* **Cleaned up the new `recoveryFallbackTimeout`** in `componentWillUnmount`, matching the existing timer cleanup pattern.

The normal user-initiated `close_session` flow is untouched: `recoveryInProgress` is only set inside `forceChatConnection`, so the warning handler still takes the original branch when the close was triggered by the user.

### Files Changed
* `src/components/Widget/index.js` — constructor flags, `componentWillUnmount` cleanup, `ready_for_message` reset, broadened error handler, branched warning handler, `onopen` skip-register hook, rewritten `forceChatConnection`.
* `src/components/Widget/socketEvents.js` — max-retry cap, exponential backoff, cap-reached UX.

### Test Plan
- [ ] `unable to register: original handler is dead`: kill the pod a session was registered on (clear `ws:pod:hb:<podID>` in Redis), then reconnect — should recover in one cycle (~1s), not loop.
- [ ] `unable to register: client from already exists`: open two tabs with the same `clientId` — second tab sends `close_session` first, gets the warning, closes, and reconnects cleanly; stable after 1–2 cycles.
- [ ] Persistent failure (wrong `channelUuid` or server keeps rejecting): reconnect attempts follow the 1s → 30s backoff and stop after 10 attempts with the "session closed" message rendered.
- [ ] Regression: clicking the widget close button still shows the session-closed message and does NOT trigger a reconnect.

Made with [Cursor](https://cursor.com)